### PR TITLE
Updated License and Copyright

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # fsdp_docs
 Documentation for the OpenFabrics Fabric Software Development Platform (FSDP)
 
-
 ## Lab Usage
 The lab is available to members of the Open Fabrics Alliance, to support the
 development and mainteance of fabric drivers and software, as well as the
@@ -16,7 +15,27 @@ TBD
 ## Lab Logical Network Layout
 ![FSDP Logical Diagram](<figures/FSDP Logical Diagram.png>)
 
-## Term of Reference & License
-* Applicable license for work is TBD.
+## Copyright
+Initial copyright on the repository is (c)2020 Red Hat, Inc.
 
-copyright
+## Copyright License Grant
+The documentation in this repository is licensed as CC BY 4.0.  This
+shall apply to all files by default.  It may be overridden on a file by
+file basis by specifically stating an alternate license directly in the
+file in question.
+
+## Grant of Copyright License by Contributors
+All submissions to this repository must use
+the [Developer Certificate of Origin](https://developercertificate.org/)
+method of Copyright License Grant
+(so all submissions must include a Signed-off-by: tag in the commit
+message).
+
+Compliance with all terms of the DCO are required, including agreement to
+license the contribution under the same terms as the existing license on
+the files being modified.
+
+Contributors maintain their own copyright ownership and grant the
+OpenFabrics Alliance a perpetual license to use their contributions
+pursuant to the terms of the DCO.
+


### PR DESCRIPTION
Update license as per proposed OpenFabrics Alliance Intellectual Policy Rights Policy.  OFA IPR Policy can be summed up as:

1) Source code: Any OSI approved open source license
2) Specifications (or other items we don't want people to modify): CC BY-ND 4.0 (or equivalent)
3) All other "Works of Authorship": CC BY 4.0 (or equivalent)

This is not source code, so 1 is not appropriate.
This is not a spec or other unmodifiable item, so 2 is not appropriate.
Therefore, fall through to #3 and set license to CC BY 4.0.

Signed-off-by: Doug Ledford <dledford@redhat.com>