### PR TITLE
corrections after sanity checks, moving a couple cables

### DIFF
--- a/builders.md
+++ b/builders.md
@@ -14,9 +14,9 @@ NOTE: This information can also be found in [network_information.md](network_inf
 | System | HPE DL325 |
 | lom0 Network | 10.12.2.252 & 2606:4100:3880:3102::252 |
 | IPMI Network | builder-00.ipmi.ofa.iol.unh.edu & 10.12.1.252 & 2606:4100:3880:3101::252 |
-| ROCE Fabric | Mellanox MCX653106A-HDAT Port 1 |
-| iWARP Fabric | Mellanox MCX653106A-HDAT Port 1 |
-| IB Fabric | Mellanox MCX653106A-HDAT Port 2 |
+| ROCE Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Mellanox QM8700 IB switch port 22)* |
+| iWARP Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Mellanox QM8700 IB switch port 22)* |
+| IB Fabric | Mellanox MCX653106A-HDAT Port 2 *(Connected to Mellanox QM8700 IB switch port 2)*|
 | OPA Fabric | Intel Omni-Path 100HFA016LS (fabric manager) |
 
 ## Usage Instructions

--- a/builders.md
+++ b/builders.md
@@ -14,9 +14,9 @@ NOTE: This information can also be found in [network_information.md](network_inf
 | System | HPE DL325 |
 | lom0 Network | 10.12.2.252 & 2606:4100:3880:3102::252 |
 | IPMI Network | builder-00.ipmi.ofa.iol.unh.edu & 10.12.1.252 & 2606:4100:3880:3101::252 |
-| ROCE Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Mellanox QM8700 IB switch port 22)* |
-| iWARP Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Mellanox QM8700 IB switch port 22)* |
-| IB Fabric | Mellanox MCX653106A-HDAT Port 2 *(Connected to Mellanox QM8700 IB switch port 2)*|
+| ROCE Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Edgecore Wedge 100BF-32x Ethernet switch port 22)* |
+| iWARP Fabric | Mellanox MCX653106A-HDAT Port 1 *(Connected to Edgecore Wedge 100BF-32x Ethernet switch port 22)* |
+| IB Fabric | Mellanox MCX653106A-HDAT Port 2 *(Connected to Mellanox QM8700 IB switch port 40)*|
 | OPA Fabric | Intel Omni-Path 100HFA016LS (fabric manager) |
 
 ## Usage Instructions

--- a/ib_fabric.md
+++ b/ib_fabric.md
@@ -18,12 +18,12 @@ when available.*
 The following test nodes have **Mellanox MCX653106A-HDAT 200G 2-port** cards installed in PCI Slot 3:
 
 * node-07.ofa.iol.unh.edu - Connected to Mellanox QM8700 IB switch port 1 *and Edgecore Wedge 100BF-32x Ethernet switch port 8*
-* node-08.ofa.iol.unh.edu - Connected to Mellanox QM8700 IB switch port 2 *and Edgecore Wedge 100BF-32x Ethernet switch port 13*
+* node-08.ofa.iol.unh.edu - Connected to *Edgecore Wedge 100BF-32x Ethernet switch port 13*
 
 The following test nodes have **Mellanox MCX556A-ECAT 100G 2-port** cards installed in PCI slot 1:
 
-* node-09.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 3 *and Edgecore Wedge 100BF-32x Ethernet switch port 11*
-* node-10.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 4 *and Edgecore Wedge 100BF-32x Ethernet switch port 15*
+* node-09.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 6 *and Edgecore Wedge 100BF-32x Ethernet switch port 11*
+* node-10.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 5 *and Edgecore Wedge 100BF-32x Ethernet switch port 15*
 
 The following test nodes have **Mellanox CX654106A 200G 2-port** cards installed in PCI slots 1 and 3:
 

--- a/network_information.md
+++ b/network_information.md
@@ -32,7 +32,7 @@ information about each of the installed NICs is listed on the
 | Host Name | Description | IPMI Network | lom0 Network | IB Fabric | ROCE Fabric | OPA Fabric | iWARP Fabric |
 | --------- | ----------- | ------------ | ------------ | --------- | ----------- | ---------- | ------------ |
 | beaker| Beaker server and lab controller (VM) | 10.12.1.253 & 2606:4100:3880:3101::253 | 10.12.2.253 & 2606:4100:3880:3102::253 | | | | |
-| builder-00 | Build server (bare-metal) | 10.12.1.252 & 2606:4100:3880:3101::252 | 10.12.2.252 & 2606:4100:3880:3102::252 | | | Intel NIC | |
+| builder-00 | Build server (bare-metal) | 10.12.1.252 & 2606:4100:3880:3101::252 | 10.12.2.252 & 2606:4100:3880:3102::252 | Mellanox NIC | Mellanox NIC | Intel NIC | Mellanox NIC |
 | pdu-1 | Power Distribution Unit #1 | 10.12.1.250 & 2606:4100:3880:3101::250 |
 | pdu-2 | Power Distribution Unit #1 | 10.12.1.251 & 2606:4100:3880:3101::251 |
 | node-01 | Test Node #01 | 10.12.1.5 & 2606:4100:3880:3101::5 | 10.12.2.5 & 2606:4100:3880:3102::5 | | Intel NICs | Intel NIC | |


### PR DESCRIPTION
Went through and double-checked to see if the documentation accurately described which IB/Ethernet switch port was connected to each node/NIC.

As of 7/8/2021, the documentation accurately reflects this information.


