### PR TITLE
Fixed cable / port connections for builder

### DIFF
--- a/ethernet_fabric.md
+++ b/ethernet_fabric.md
@@ -13,13 +13,11 @@ The switch's management interface can be accessed via **edgecore.ofa.iol.unh.edu
 
 In the port definitions below, the power numbers refer to the 40G / 100G port. When
 that port is connected to a breakout cable, either to 10G or 25G, the physical
-sub-port is indicated as the second number.  *Logical ports in SONiC will be updated
-when available.*
+sub-port is indicated as the second number.  *Logical ports in SONiC will be updated when available.*
 
-## Fabric "Manager"
+## Fabric "Manager" & Builder
 
-The [builder-00.ofa.iol.unh.edu](bulders.md) acts as the fabric "manager" through port 1 of
-the Mellanox MCX653106A-HDAT card, which is connected to switch port 32.
+The [builder-00.ofa.iol.unh.edu](bulders.md) acts as the fabric "manager" through port 1 of the Mellanox MCX653106A-HDAT card, which is connected to switch port 22.
 
 ## Test Nodes
 

--- a/ib_fabric.md
+++ b/ib_fabric.md
@@ -13,17 +13,21 @@ that port is connected to a breakout cable, either to 10G or 25G, the physical
 sub-port is indicated as the second number.  *Logical ports will be updated
 when available.*
 
+## Builder
+
+The [builder-00.ofa.iol.unh.edu](bulders.md) includes a Mellanox MCX653106A-HDAT card, with port 2 connected to switch port 40.
+
 ## Test Nodes
 
 The following test nodes have **Mellanox MCX653106A-HDAT 200G 2-port** cards installed in PCI Slot 3:
 
-* node-07.ofa.iol.unh.edu - Connected to Mellanox QM8700 IB switch port 1 *and Edgecore Wedge 100BF-32x Ethernet switch port 8*
-* node-08.ofa.iol.unh.edu - Connected to *Edgecore Wedge 100BF-32x Ethernet switch port 13*
+* node-07.ofa.iol.unh.edu - Port 1 is connected to Mellanox QM8700 IB switch port 1 and port 2 is connected to Edgecore Wedge 100BF-32x Ethernet switch port 8
+* node-08.ofa.iol.unh.edu - Port 1 is connected to Mellanox QM8700 IB switch port 2 and port 2 is connected to Edgecore Wedge 100BF-32x Ethernet switch port 13
 
 The following test nodes have **Mellanox MCX556A-ECAT 100G 2-port** cards installed in PCI slot 1:
 
-* node-09.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 6 *and Edgecore Wedge 100BF-32x Ethernet switch port 11*
-* node-10.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 5 *and Edgecore Wedge 100BF-32x Ethernet switch port 15*
+* node-09.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 6 and Edgecore Wedge 100BF-32x Ethernet switch port 11
+* node-10.ofa.iol.unh.edu - Connected to  Mellanox QM8700 IB switch port 5 and Edgecore Wedge 100BF-32x Ethernet switch port 15
 
 The following test nodes have **Mellanox CX654106A 200G 2-port** cards installed in PCI slots 1 and 3:
 


### PR DESCRIPTION
* Fixed the cable connection information for builder.
* Fixed missing IB cable connection on Test Node 8.