### PR TITLE
Added documentation for public_html directories

### DIFF
--- a/builders.md
+++ b/builders.md
@@ -90,3 +90,27 @@ TBA
 #### builder-rhel9
 
 TBA
+
+### HTML File Access
+
+To enable cluster users to easily move artifacts from their build environments to
+the test nodes, the build servers have been configured to support user public_html
+directorys.  You will need to take the following steps to create a public_html
+root in your home directory.  Note, any files placed this directory will be made
+availble to all logged in users in the cluster, unless you take the steps below
+to add a password (http basic authentication).  The steps to enable the password
+are optional and at your discretion.
+
+1. Create the directory, `mkdir ~/public_html`
+1. Create the .htaccess file with the contents below, `vim ~/public_html/.htaccess`
+Note, you need to replace username with your actually username on the system.
+1. Create your password, `htpasswd -c ~/public_html/.htpasswd USERNAME`
+
+#### .htaccess file contents
+
+```bash
+AuthType Basic
+AuthName "Password Required"
+Require valid-user
+AuthUserFile /home/USERNAME/public_html/.htpasswd
+```


### PR DESCRIPTION
* Builder-00 has been setup for public_html directories.
* Users can create these within their home directory.
* Steps for http basic auth are included.
* Fixes #20 