### PR TITLE
Card moves 12/2/21

### DIFF
--- a/ethernet_fabric.md
+++ b/ethernet_fabric.md
@@ -33,8 +33,8 @@ The [builder-00.ofa.iol.unh.edu](bulders.md) acts as the fabric "manager" throug
 | 6           | 2        | Ethernet21      |        |                    | node-03 Chelsio T6225 T6 25G 2-port iWARP Port 2
 | 6           | 3        | Ethernet22      | iWARP  | U(50), T(51,52)    | node-04 Chelsio T6225 T6 25G 2-port iWARP Port 1
 | 6           | 4        | Ethernet23      |        |                    | node-04 Chelsio T6225 T6 25G 2-port iWARP Port 2
-| 7           | N/A      | Ethernet24      | ROCE   | U(40), T(43,45)    | node-07 Mellanox 653106A 200G 2-port VPI Port 2
-| 8           | N/A      | Ethernet28      | ROCE   | U(40), T(43,45)    | node-08 Mellanox 653106A 200G 2-port VPI Port 2
+| 7           | N/A      | Ethernet24      | ROCE   | U(40), T(43,45)    | node-05 Mellanox 653106A 200G 2-port VPI Port 2
+| 8           | N/A      | Ethernet28      | ROCE   | U(40), T(43,45)    | node-06 Mellanox 653106A 200G 2-port VPI Port 2
 | 9           | 1        | Ethernet32      | ROCE   | U(40), T(43,45)    | node-05 Broadcom 57414 25G 2-port RoCE Port 1
 | 9           | 2        | Ethernet33      |        |                    | node-05 Broadcom 57414 25G 2-port RoCE Port 2
 | 9           | 3        | Ethernet34      | ROCE   | U(40), T(43,45)    | node-06 Broadcom 57414 25G 2-port RoCE Port 1

--- a/ib_fabric.md
+++ b/ib_fabric.md
@@ -23,8 +23,8 @@ The fabric switch ports are currently connected as follows.
 
 | Switch Port | Connected To                                                       |
 |-------------|--------------------------------------------------------------------|
-| 1           | node-07 Mellanox 653106A 200G 2-port VPI Port 1                    |
-| 2           | node-08 Mellanox 653106A 200G 2-port VPI Port 1                    |
+| 1           | node-05 Mellanox 653106A 200G 2-port VPI Port 1                    |
+| 2           | node-06 Mellanox 653106A 200G 2-port VPI Port 1                    |
 | 3           | node-03 Mellanox 556A ConnectX-5 VPI 100G Port 1                   |
 | 4           | node-04 Mellanox 556A ConnectX-5 VPI 100G Port 1                   |
 | 5           | node-10 Mellanox 654106A ConnectX-6 200G 2-port VPI Port 1         |

--- a/test_nodes.md
+++ b/test_nodes.md
@@ -43,23 +43,23 @@ address details for each node.
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Broadcom 57414 25G 2-port RoCE                | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
-|           | 3        | Empty                                         |      |      |     |      |    |
+|           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
 |           |          |                                               |      |      |     |      |    |
 | node-06   | 1        | Chelsio T62100 T6 100G 2-port iWARP           | 1    |      |     |      | x  |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Broadcom 57414 25G 2-port RoCE                | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
-|           | 3        | Empty                                         |      |      |     |      |    |
+|           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
 |           |          |                                               |      |      |     |      |    |
 | node-07   | 1        | Broadcom 57508 200G 1-port RoCE               | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Mellanox 631105AN 50G 1-port RoCE             | 1    |      |     | x    |    |
-|           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
+|           | 3        | Empty                                         |      |      |     |      |    |
 |           |          |                                               | 2    |      |     | x    |    |
 | node-08   | 1        | Broadcom 57508 200G 1-port RoCE               | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Mellanox 631105AN 50G 1-port RoCE             | 1    |      |     | x    |    |
-|           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
+|           | 3        | Empty                                         |      |      |     |      |    |
 |           |          |                                               | 2    |      |     | x    |    |
 | node-09   | 1&3      | Mellanox 654106A ConnectX-6 200G 2-port VPI   | 1    |      | x   |      |    |
 |           |          |                                               | 2    |      |     | x    |    |

--- a/test_nodes.md
+++ b/test_nodes.md
@@ -44,23 +44,23 @@ address details for each node.
 |           | 2        | Broadcom 57414 25G 2-port RoCE                | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
-|           |          |                                               |      |      |     |      |    |
+|           |          |                                               | 2    |      |     | x    |    |
 | node-06   | 1        | Chelsio T62100 T6 100G 2-port iWARP           | 1    |      |     |      | x  |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Broadcom 57414 25G 2-port RoCE                | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 3        | Mellanox 653106A 200G 2-port VPI              | 1    |      | x   |      |    |
-|           |          |                                               |      |      |     |      |    |
+|           |          |                                               | 2    |      |     | x    |    |
 | node-07   | 1        | Broadcom 57508 200G 1-port RoCE               | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Mellanox 631105AN 50G 1-port RoCE             | 1    |      |     | x    |    |
 |           | 3        | Empty                                         |      |      |     |      |    |
-|           |          |                                               | 2    |      |     | x    |    |
+|           |          |                                               |      |      |     |      |    |
 | node-08   | 1        | Broadcom 57508 200G 1-port RoCE               | 1    |      |     | x    |    |
 |           |          |                                               | 2    |      |     |      |    |
 |           | 2        | Mellanox 631105AN 50G 1-port RoCE             | 1    |      |     | x    |    |
 |           | 3        | Empty                                         |      |      |     |      |    |
-|           |          |                                               | 2    |      |     | x    |    |
+|           |          |                                               |      |      |     |      |    |
 | node-09   | 1&3      | Mellanox 654106A ConnectX-6 200G 2-port VPI   | 1    |      | x   |      |    |
 |           |          |                                               | 2    |      |     | x    |    |
 |           | 2        | QLogic FastLinQ QL41212 25G 2-port RoCE       | 1    |      |     | x    |    |


### PR DESCRIPTION
*moved Mellanox 653106A 200G 2-port VPI from port 3 on node-07 to port 3
on node-05
*moved Mellanox 653106A 200G 2-port VPI from port 3 on node-08 to port 3
on node-06

resolves #86 

Signed-off-by: Jeremy Spewock <jspewock@iol.unh.edu>